### PR TITLE
[FEAT] Notification API 개발

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -303,6 +303,65 @@ public interface HostRepository extends JpaRepository<Host, Long> {
 7. 도메인별로 패키지를 분리하여 관심사 분리
 8. **Facade 패턴**: 여러 도메인의 서비스를 조합하는 복잡한 비즈니스 로직은 Facade에서 처리
 
+### 17. Controller 계층 규칙
+```java
+// Controller는 단순히 Facade 메서드 호출만 담당
+@RestController
+@RequestMapping("/api/v1/example")
+@RequiredArgsConstructor
+public class ExampleController {
+    
+    private final ExampleFacade exampleFacade;
+    
+    @PostMapping
+    public BaseResponse<ExampleResponse> createExample(
+            @RequestBody ExampleRequest request,
+            @AuthenticationMember Long memberId) {
+        
+        // Controller에서는 단순히 Facade 호출만
+        return BaseResponse.onSuccess(exampleFacade.createExample(request, memberId));
+    }
+}
+```
+
+#### Controller 계층 금지사항:
+- ❌ 비즈니스 로직 구현
+- ❌ 데이터 변환 로직
+- ❌ 권한 확인 로직
+- ❌ 복잡한 조건문이나 반복문
+- ❌ 여러 서비스 직접 호출
+
+#### Controller 계층 허용사항:
+- ✅ Facade 메서드 호출
+- ✅ Request/Response 매핑
+- ✅ Swagger 어노테이션
+- ✅ 인증 정보 주입 (@AuthenticationMember)
+
+### 18. @AuthenticationMember 사용 규칙
+```java
+// ✅ 올바른 사용법: Member 객체를 받아서 ID 추출
+@GetMapping
+public BaseResponse<ExampleResponse> getExample(
+        @AuthenticationMember Member member) {
+    
+    return BaseResponse.onSuccess(exampleFacade.getExample(member.getId()));
+}
+
+// ❌ 잘못된 사용법: Long memberId 직접 사용
+@GetMapping
+public BaseResponse<ExampleResponse> getExample(
+        @AuthenticationMember Long memberId) {  // null 반환됨
+    
+    return BaseResponse.onSuccess(exampleFacade.getExample(memberId));
+}
+```
+
+#### @AuthenticationMember 규칙:
+- **반드시 `Member` 객체로 받기**: `@AuthenticationMember Member member`
+- **ID 추출**: `member.getId()`로 memberId 사용
+- **null 체크 불필요**: 인증된 사용자만 접근 가능한 API에서 사용
+- **일관성 유지**: 모든 Controller에서 동일한 패턴 사용
+
 ## 코드 작성 시 준수사항
 - 기존 코드 스타일과 일관성 유지
 - 한국어 주석 사용 (비즈니스 로직 설명)

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/common/config/SecurityConfig.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/common/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/hosts/**").authenticated()
                         .requestMatchers("/api/v1/reviews/**").authenticated()
                         .requestMatchers("/api/v1/matches/**").authenticated()
+                        .requestMatchers("/api/v1/notifications/**").authenticated()
                         .anyRequest().denyAll());
         http
                 .addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class);

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/application/v1/MatchFacade.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/application/v1/MatchFacade.java
@@ -31,6 +31,14 @@ public interface MatchFacade {
     List<MatchRequestDTO.MatchDetail> getMatchesByMemberId(Long memberId);
     
     /**
+     * 사용자 ID로 매칭 목록을 조회합니다 (호스트/회원 모두 포함).
+     * 
+     * @param userId 사용자 ID
+     * @return 매칭 목록
+     */
+    List<MatchRequestDTO.MatchDetail> getMatchesByUserId(Long userId);
+    
+    /**
      * 특정 매칭의 상세 정보를 조회합니다.
      * 
      * @param matchId 매칭 ID
@@ -45,4 +53,14 @@ public interface MatchFacade {
      * @param memberId 회원 ID
      */
     void cancelMatch(Long matchId, Long memberId);
+    
+    /**
+     * 매칭 상태를 변경합니다.
+     * 
+     * @param matchId 매칭 ID
+     * @param newStatus 새로운 매칭 상태
+     * @param memberId 회원 ID (호스트 권한 확인용)
+     * @return 변경된 매칭 정보
+     */
+    MatchRequestDTO.MatchDetail updateMatchingStatus(Long matchId, String newStatus, Long memberId);
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/application/v1/MatchFacadeImpl.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/application/v1/MatchFacadeImpl.java
@@ -1,7 +1,10 @@
 package com.jimjim.lugeasy.match.application.v1;
 
 import com.jimjim.lugeasy.match.application.v1.dto.MatchRequestDTO;
+import com.jimjim.lugeasy.match.domain.Matching;
+import com.jimjim.lugeasy.match.domain.MatchingStatus;
 import com.jimjim.lugeasy.match.service.MatchService;
+import com.jimjim.lugeasy.notification.service.NotificationService;
 import com.jimjim.lugeasy.user.domain.Member;
 import com.jimjim.lugeasy.user.service.HostService;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,9 @@ public class MatchFacadeImpl implements MatchFacade {
 
     // User Domain (회원 정보 조회용)
     private final HostService hostService;
+    
+    // Notification Domain (알림 생성용)
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -34,13 +40,26 @@ public class MatchFacadeImpl implements MatchFacade {
         Member member = hostService.getMemberById(memberId);
         
         // MatchService를 통해 매칭 생성 (Match 도메인)
-        return matchService.createMatch(member, hostId, dropOffTime, findingTime);
+        MatchRequestDTO.CreateMatchResponse response = matchService.createMatch(member, hostId, dropOffTime, findingTime);
+        
+        // 매칭 생성 후 호스트에게 알림 전송
+        Matching createdMatching = matchService.getMatchingById(response.getMatchId());
+        Member hostMember = createdMatching.getHost().getMember();
+        notificationService.createNotification(createdMatching, hostMember);
+        
+        return response;
     }
 
     @Override
     public List<MatchRequestDTO.MatchDetail> getMatchesByMemberId(Long memberId) {
         // MatchService를 통해 매칭 목록 조회 (Match 도메인)
         return matchService.getMatchesByMemberId(memberId);
+    }
+    
+    @Override
+    public List<MatchRequestDTO.MatchDetail> getMatchesByUserId(Long userId) {
+        // MatchService를 통해 통합 매칭 목록 조회 (Match 도메인)
+        return matchService.getMatchesByUserId(userId);
     }
 
     @Override
@@ -54,5 +73,40 @@ public class MatchFacadeImpl implements MatchFacade {
     public void cancelMatch(Long matchId, Long memberId) {
         // MatchService를 통해 매칭 취소 (Match 도메인)
         matchService.cancelMatch(matchId, memberId);
+    }
+    
+    @Override
+    @Transactional
+    public MatchRequestDTO.MatchDetail updateMatchingStatus(Long matchId, String newStatus, Long memberId) {
+        // 매칭 상태 변경 (Match 도메인)
+        MatchingStatus status = MatchingStatus.valueOf(newStatus);
+        Matching updatedMatching = matchService.updateMatchingStatus(matchId, status, memberId);
+        
+        // 알림 생성 (Notification 도메인)
+        // 상태를 변경한 사람이 아닌 상대방에게 알림 전송
+        Member targetMember;
+        if (updatedMatching.getHost().getMember().getId().equals(memberId)) {
+            // 호스트가 변경했으므로 멤버에게 알림
+            targetMember = updatedMatching.getMember();
+        } else {
+            // 멤버가 변경했으므로 호스트에게 알림
+            targetMember = updatedMatching.getHost().getMember();
+        }
+        notificationService.createNotification(updatedMatching, targetMember);
+        
+        // DTO 변환하여 반환
+        return MatchRequestDTO.MatchDetail.builder()
+                .matchId(updatedMatching.getId())
+                .hostId(updatedMatching.getHost().getId())
+                .hostName(updatedMatching.getHost().getMember().getName())
+                .hostAddress(updatedMatching.getHost().getAddress())
+                .memberId(updatedMatching.getMember().getId())
+                .memberName(updatedMatching.getMember().getName())
+                .dropOffTime(updatedMatching.getDropOffTime())
+                .findingTime(updatedMatching.getFindingTime())
+                .status(updatedMatching.getMatchingStatus().toString())
+                .userRole(updatedMatching.getHost().getMember().getId().equals(memberId) ? "HOST" : "MEMBER")
+                .createdAt(updatedMatching.getCreatedAt())
+                .build();
     }
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/application/v1/dto/MatchRequestDTO.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/application/v1/dto/MatchRequestDTO.java
@@ -64,6 +64,12 @@ public class MatchRequestDTO {
         @Schema(description = "호스트 주소")
         private String hostAddress;
 
+        @Schema(description = "회원 ID")
+        private Long memberId;
+
+        @Schema(description = "회원 이름")
+        private String memberName;
+
         @Schema(description = "짐 맡기기 시간")
         private LocalDateTime dropOffTime;
 
@@ -73,7 +79,21 @@ public class MatchRequestDTO {
         @Schema(description = "매칭 상태")
         private String status;
 
+        @Schema(description = "사용자 역할 (HOST/MEMBER)")
+        private String userRole;
+
         @Schema(description = "매칭 생성 시간")
         private LocalDateTime createdAt;
+    }
+    
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "매칭 상태 변경 요청 DTO")
+    public static class UpdateMatchingStatusRequest {
+        @Schema(description = "새로운 매칭 상태", example = "MATCHED", required = true)
+        @NotNull(message = "매칭 상태는 필수입니다")
+        private String status;
     }
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/domain/Matching.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/domain/Matching.java
@@ -37,7 +37,12 @@ public class Matching extends BaseEntity {
 
     // host에 address가 있는데 주소/위도/경도 표시해야 하나?
 
-
-
-
+    /**
+     * 매칭 상태를 변경합니다.
+     * 
+     * @param newStatus 새로운 매칭 상태
+     */
+    public void updateMatchingStatus(MatchingStatus newStatus) {
+        this.matchingStatus = newStatus;
+    }
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/errorCode/MatchErrorCode.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/errorCode/MatchErrorCode.java
@@ -17,6 +17,10 @@ public enum MatchErrorCode implements ErrorCodeInterface {
     HOST_NOT_FOUND("MATCH005", "호스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_TIME_RANGE("MATCH006", "짐 맡기기 시간은 짐 찾기 시간보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
     MATCH_STATUS_UPDATE_FAILED("MATCH007", "매칭 상태 변경 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_STATUS_TRANSITION("MATCH008", "유효하지 않은 상태 변경입니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_CANCEL_AFTER_SERVICE_START("MATCH009", "서비스 시작 후에는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_COMPLETE_BEFORE_SERVICE_END("MATCH010", "서비스 종료 전에는 완료 처리할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_MODIFY_FINAL_STATUS("MATCH011", "완료되거나 거절된 매칭은 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String code;

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/errorCode/MatchErrorCode.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/errorCode/MatchErrorCode.java
@@ -16,6 +16,7 @@ public enum MatchErrorCode implements ErrorCodeInterface {
     MATCH_CANNOT_CANCEL("MATCH004", "취소할 수 없는 매칭 상태입니다.", HttpStatus.BAD_REQUEST),
     HOST_NOT_FOUND("MATCH005", "호스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_TIME_RANGE("MATCH006", "짐 맡기기 시간은 짐 찾기 시간보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
+    MATCH_STATUS_UPDATE_FAILED("MATCH007", "매칭 상태 변경 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 
     private final String code;

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/representation/v1/MatchController.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/representation/v1/MatchController.java
@@ -79,7 +79,7 @@ public class MatchController {
         return BaseResponse.onSuccess(response);
     }
 
-    @Operation(summary = "매칭 목록 조회", description = "회원의 매칭 목록을 조회합니다.")
+    @Operation(summary = "매칭 목록 조회 (통합)", description = "사용자의 모든 매칭 목록을 조회합니다 (호스트/회원 모두 포함).")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "매칭 목록 조회 성공",
             content = @Content(mediaType = "application/json",
@@ -96,9 +96,12 @@ public class MatchController {
                           "host_id": 1,
                           "host_name": "김태린",
                           "host_address": "서울시 노원구 화랑로 123",
+                          "member_id": 11,
+                          "member_name": "일반사용자1",
                           "drop_off_time": "2024-03-26T11:00:00",
                           "finding_time": "2024-03-28T23:00:00",
                           "status": "REQUESTED",
+                          "user_role": "HOST",
                           "created_at": "2024-03-25T10:00:00"
                         }
                       ]
@@ -110,6 +113,48 @@ public class MatchController {
     })
     @GetMapping
     public BaseResponse<List<MatchRequestDTO.MatchDetail>> getMatches(
+            @AuthenticationMember Member member) {
+        
+        List<MatchRequestDTO.MatchDetail> matches = 
+                matchFacade.getMatchesByUserId(member.getId());
+        
+        return BaseResponse.onSuccess(matches);
+    }
+    
+    @Operation(summary = "회원 매칭 목록 조회", description = "회원으로 참여한 매칭 목록만 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "회원 매칭 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(
+                    name = "회원 매칭 목록 조회 성공 응답",
+                    value = """
+                    {
+                      "timestamp": "2025-08-31T09:45:40.426159645Z",
+                      "code": "COMMON200",
+                      "message": "요청에 성공하였습니다.",
+                      "result": [
+                        {
+                          "match_id": 1,
+                          "host_id": 1,
+                          "host_name": "김태린",
+                          "host_address": "서울시 노원구 화랑로 123",
+                          "member_id": 11,
+                          "member_name": "일반사용자1",
+                          "drop_off_time": "2024-03-26T11:00:00",
+                          "finding_time": "2024-03-28T23:00:00",
+                          "status": "REQUESTED",
+                          "user_role": "MEMBER",
+                          "created_at": "2024-03-25T10:00:00"
+                        }
+                      ]
+                    }
+                    """
+                )
+            )
+        )
+    })
+    @GetMapping("/as-member")
+    public BaseResponse<List<MatchRequestDTO.MatchDetail>> getMatchesAsMember(
             @AuthenticationMember Member member) {
         
         List<MatchRequestDTO.MatchDetail> matches = 
@@ -134,9 +179,12 @@ public class MatchController {
                         "host_id": 1,
                         "host_name": "김태린",
                         "host_address": "서울시 노원구 화랑로 123",
+                        "member_id": 11,
+                        "member_name": "일반사용자1",
                         "drop_off_time": "2024-03-26T11:00:00",
                         "finding_time": "2024-03-28T23:00:00",
                         "status": "REQUESTED",
+                        "user_role": "HOST",
                         "created_at": "2024-03-25T10:00:00"
                       }
                     }
@@ -181,5 +229,59 @@ public class MatchController {
         matchFacade.cancelMatch(matchId, member.getId());
         
         return BaseResponse.onSuccess(null);
+    }
+    
+    @Operation(summary = "매칭 상태 변경", description = "호스트가 매칭 상태를 변경합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "매칭 상태 변경 성공",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(
+                    name = "매칭 상태 변경 성공 응답",
+                    value = """
+                    {
+                      "timestamp": "2025-08-31T09:45:40.426159645Z",
+                      "code": "COMMON200",
+                      "message": "요청에 성공하였습니다.",
+                      "result": {
+                        "match_id": 1,
+                        "host_id": 1,
+                        "host_name": "김태린",
+                        "host_address": "서울시 노원구 화랑로 123",
+                        "drop_off_time": "2024-03-26T11:00:00",
+                        "finding_time": "2024-03-28T23:00:00",
+                        "status": "MATCHED",
+                        "created_at": "2024-03-25T10:00:00"
+                      }
+                    }
+                    """
+                )
+            )
+        )
+    })
+    @PatchMapping("/{matchId}/status")
+    public BaseResponse<MatchRequestDTO.MatchDetail> updateMatchingStatus(
+            @AuthenticationMember Member member,
+            @Parameter(description = "매칭 ID", example = "1") @PathVariable Long matchId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "매칭 상태 변경",
+                required = true,
+                content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                        name = "매칭 상태 변경 예시",
+                        value = """
+                        {
+                          "status": "MATCHED"
+                        }
+                        """
+                    )
+                )
+            )
+            @RequestBody MatchRequestDTO.UpdateMatchingStatusRequest request) {
+        
+        return BaseResponse.onSuccess(matchFacade.updateMatchingStatus(
+            matchId, 
+            request.getStatus(), 
+            member.getId()));
     }
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/MatchService.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/MatchService.java
@@ -33,6 +33,14 @@ public interface MatchService {
     List<MatchRequestDTO.MatchDetail> getMatchesByMemberId(Long memberId);
     
     /**
+     * 사용자 ID로 매칭 목록을 조회합니다 (호스트/회원 모두 포함).
+     * 
+     * @param userId 사용자 ID
+     * @return 매칭 목록
+     */
+    List<MatchRequestDTO.MatchDetail> getMatchesByUserId(Long userId);
+    
+    /**
      * 특정 매칭의 상세 정보를 조회합니다.
      * 
      * @param matchId 매칭 ID
@@ -47,4 +55,22 @@ public interface MatchService {
      * @param memberId 회원 ID
      */
     void cancelMatch(Long matchId, Long memberId);
+    
+    /**
+     * 매칭 ID로 매칭 엔티티를 조회합니다.
+     * 
+     * @param matchId 매칭 ID
+     * @return 매칭 엔티티
+     */
+    Matching getMatchingById(Long matchId);
+    
+    /**
+     * 매칭 상태를 변경합니다.
+     * 
+     * @param matchId 매칭 ID
+     * @param newStatus 새로운 매칭 상태
+     * @param memberId 회원 ID (권한 확인용)
+     * @return 변경된 매칭 정보
+     */
+    Matching updateMatchingStatus(Long matchId, com.jimjim.lugeasy.match.domain.MatchingStatus newStatus, Long memberId);
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/MatchService.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/MatchService.java
@@ -73,4 +73,15 @@ public interface MatchService {
      * @return 변경된 매칭 정보
      */
     Matching updateMatchingStatus(Long matchId, com.jimjim.lugeasy.match.domain.MatchingStatus newStatus, Long memberId);
+    
+    /**
+     * 매칭 상태 변경 가능 여부를 검증합니다.
+     * 
+     * @param currentStatus 현재 상태
+     * @param newStatus 새로운 상태
+     * @param matching 매칭 정보
+     */
+    void validateStatusTransition(com.jimjim.lugeasy.match.domain.MatchingStatus currentStatus, 
+                                 com.jimjim.lugeasy.match.domain.MatchingStatus newStatus, 
+                                 Matching matching);
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/impl/MatchServiceImpl.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/impl/MatchServiceImpl.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -66,7 +68,68 @@ public class MatchServiceImpl implements MatchService {
         List<Matching> matchings = matchingRepository.findByMemberId(memberId);
         
         return matchings.stream()
-                .map(this::convertToMatchDetail)
+                .map(matching -> MatchRequestDTO.MatchDetail.builder()
+                        .matchId(matching.getId())
+                        .hostId(matching.getHost().getId())
+                        .hostName(matching.getHost().getMember().getName())
+                        .hostAddress(matching.getHost().getAddress())
+                        .memberId(matching.getMember().getId())
+                        .memberName(matching.getMember().getName())
+                        .dropOffTime(matching.getDropOffTime())
+                        .findingTime(matching.getFindingTime())
+                        .status(matching.getMatchingStatus().toString())
+                        .userRole("MEMBER")
+                        .createdAt(matching.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    public List<MatchRequestDTO.MatchDetail> getMatchesByUserId(Long userId) {
+        // 호스트로 참여한 매칭 조회
+        List<Matching> hostMatchings = matchingRepository.findByHostId(userId);
+        List<MatchRequestDTO.MatchDetail> hostMatches = hostMatchings.stream()
+                .map(matching -> MatchRequestDTO.MatchDetail.builder()
+                        .matchId(matching.getId())
+                        .hostId(matching.getHost().getId())
+                        .hostName(matching.getHost().getMember().getName())
+                        .hostAddress(matching.getHost().getAddress())
+                        .memberId(matching.getMember().getId())
+                        .memberName(matching.getMember().getName())
+                        .dropOffTime(matching.getDropOffTime())
+                        .findingTime(matching.getFindingTime())
+                        .status(matching.getMatchingStatus().toString())
+                        .userRole("HOST")
+                        .createdAt(matching.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+        
+        // 회원으로 참여한 매칭 조회
+        List<Matching> memberMatchings = matchingRepository.findByMemberId(userId);
+        List<MatchRequestDTO.MatchDetail> memberMatches = memberMatchings.stream()
+                .map(matching -> MatchRequestDTO.MatchDetail.builder()
+                        .matchId(matching.getId())
+                        .hostId(matching.getHost().getId())
+                        .hostName(matching.getHost().getMember().getName())
+                        .hostAddress(matching.getHost().getAddress())
+                        .memberId(matching.getMember().getId())
+                        .memberName(matching.getMember().getName())
+                        .dropOffTime(matching.getDropOffTime())
+                        .findingTime(matching.getFindingTime())
+                        .status(matching.getMatchingStatus().toString())
+                        .userRole("MEMBER")
+                        .createdAt(matching.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+        
+        // 두 리스트를 합치고 생성 시간 순으로 정렬
+        List<MatchRequestDTO.MatchDetail> allMatches = new ArrayList<>();
+        allMatches.addAll(hostMatches);
+        allMatches.addAll(memberMatches);
+        
+        return allMatches.stream()
+                .sorted(Comparator.comparing(MatchRequestDTO.MatchDetail::getCreatedAt, 
+                        Comparator.nullsLast(Comparator.reverseOrder())))
                 .collect(Collectors.toList());
     }
 
@@ -75,7 +138,16 @@ public class MatchServiceImpl implements MatchService {
         Matching matching = matchingRepository.findById(matchId)
                 .orElseThrow(() -> new RestApiException(MatchErrorCode.MATCH_NOT_FOUND));
         
-        return convertToMatchDetail(matching);
+        return MatchRequestDTO.MatchDetail.builder()
+                .matchId(matching.getId())
+                .hostId(matching.getHost().getId())
+                .hostName(matching.getHost().getMember().getName())
+                .hostAddress(matching.getHost().getAddress())
+                .dropOffTime(matching.getDropOffTime())
+                .findingTime(matching.getFindingTime())
+                .status(matching.getMatchingStatus().toString())
+                .createdAt(matching.getCreatedAt())
+                .build();
     }
 
     @Override
@@ -98,16 +170,30 @@ public class MatchServiceImpl implements MatchService {
         matchingRepository.delete(matching);
     }
     
-    private MatchRequestDTO.MatchDetail convertToMatchDetail(Matching matching) {
-        return MatchRequestDTO.MatchDetail.builder()
-                .matchId(matching.getId())
-                .hostId(matching.getHost().getId())
-                .hostName(matching.getHost().getMember().getName())
-                .hostAddress(matching.getHost().getAddress())
-                .dropOffTime(matching.getDropOffTime())
-                .findingTime(matching.getFindingTime())
-                .status(matching.getMatchingStatus().toString())
-                .createdAt(matching.getCreatedAt())
-                .build();
+    @Override
+    public Matching getMatchingById(Long matchId) {
+        return matchingRepository.findById(matchId)
+                .orElseThrow(() -> new RestApiException(MatchErrorCode.MATCH_NOT_FOUND));
+    }
+    
+    @Override
+    @Transactional
+    public Matching updateMatchingStatus(Long matchId, MatchingStatus newStatus, Long memberId) {
+        // 매칭 존재 여부 확인
+        Matching matching = matchingRepository.findById(matchId)
+                .orElseThrow(() -> new RestApiException(MatchErrorCode.MATCH_NOT_FOUND));
+        
+        // 권한 확인 (호스트 또는 멤버만 변경 가능)
+        boolean isHost = matching.getHost().getMember().getId().equals(memberId);
+        boolean isMember = matching.getMember().getId().equals(memberId);
+        
+        if (!isHost && !isMember) {
+            throw new RestApiException(MatchErrorCode.MATCH_NOT_OWNED);
+        }
+        
+        // 매칭 상태 변경
+        matching.updateMatchingStatus(newStatus);
+        
+        return matchingRepository.save(matching);
     }
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/impl/MatchServiceImpl.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/match/service/impl/MatchServiceImpl.java
@@ -191,9 +191,67 @@ public class MatchServiceImpl implements MatchService {
             throw new RestApiException(MatchErrorCode.MATCH_NOT_OWNED);
         }
         
+        // 상태 전환 검증
+        validateStatusTransition(matching.getMatchingStatus(), newStatus, matching);
+        
         // 매칭 상태 변경
         matching.updateMatchingStatus(newStatus);
         
         return matchingRepository.save(matching);
+    }
+    
+    @Override
+    public void validateStatusTransition(MatchingStatus currentStatus, MatchingStatus newStatus, Matching matching) {
+        // 1. 기본 상태 전환 규칙 검증
+        if (!isValidTransition(currentStatus, newStatus)) {
+            throw new RestApiException(MatchErrorCode.INVALID_STATUS_TRANSITION);
+        }
+        
+        // 2. 최종 상태에서 변경 불가 검증
+        if (isFinalStatus(currentStatus)) {
+            throw new RestApiException(MatchErrorCode.CANNOT_MODIFY_FINAL_STATUS);
+        }
+        
+        // 3. 시간 기반 제약 검증
+        validateTimeBasedConstraints(currentStatus, newStatus, matching);
+    }
+    
+    /**
+     * 유효한 상태 전환인지 확인합니다.
+     */
+    private boolean isValidTransition(MatchingStatus current, MatchingStatus next) {
+        return switch (current) {
+            case REQUESTED -> next == MatchingStatus.MATCHED || next == MatchingStatus.REJECTED;
+            case MATCHED -> next == MatchingStatus.COMPLETED || next == MatchingStatus.REJECTED;
+            case COMPLETED, REJECTED -> false; // 최종 상태
+        };
+    }
+    
+    /**
+     * 최종 상태인지 확인합니다.
+     */
+    private boolean isFinalStatus(MatchingStatus status) {
+        return status == MatchingStatus.COMPLETED || status == MatchingStatus.REJECTED;
+    }
+    
+    /**
+     * 시간 기반 제약을 검증합니다.
+     */
+    private void validateTimeBasedConstraints(MatchingStatus currentStatus, MatchingStatus newStatus, Matching matching) {
+        LocalDateTime now = LocalDateTime.now();
+        
+        // MATCHED → REJECTED: 서비스 시작 전에만 가능
+        if (currentStatus == MatchingStatus.MATCHED && newStatus == MatchingStatus.REJECTED) {
+            if (now.isAfter(matching.getDropOffTime())) {
+                throw new RestApiException(MatchErrorCode.CANNOT_CANCEL_AFTER_SERVICE_START);
+            }
+        }
+        
+        // MATCHED → COMPLETED: 서비스 종료 후에만 가능
+        if (currentStatus == MatchingStatus.MATCHED && newStatus == MatchingStatus.COMPLETED) {
+            if (now.isBefore(matching.getFindingTime())) {
+                throw new RestApiException(MatchErrorCode.CANNOT_COMPLETE_BEFORE_SERVICE_END);
+            }
+        }
     }
 }

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/application/v1/NotificationFacade.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/application/v1/NotificationFacade.java
@@ -1,0 +1,43 @@
+package com.jimjim.lugeasy.notification.application.v1;
+
+import com.jimjim.lugeasy.notification.application.v1.dto.NotificationResponseDTO;
+
+public interface NotificationFacade {
+    
+    /**
+     * 회원의 알림 목록을 조회합니다 (오늘/지난 알림 분리).
+     * 
+     * @param memberId 회원 ID
+     * @return 알림 목록 (오늘/지난 알림 분리)
+     */
+    NotificationResponseDTO.NotificationListResponse getNotifications(Long memberId);
+    
+    /**
+     * 특정 알림을 삭제합니다.
+     * 
+     * @param notificationId 알림 ID
+     * @param memberId 회원 ID
+     */
+    void deleteNotification(Long notificationId, Long memberId);
+    
+    /**
+     * 회원의 모든 알림을 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteAllNotifications(Long memberId);
+    
+    /**
+     * 회원의 오늘 알림을 모두 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteTodayNotifications(Long memberId);
+    
+    /**
+     * 회원의 지난 알림을 모두 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteEarlierNotifications(Long memberId);
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/application/v1/NotificationFacadeImpl.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/application/v1/NotificationFacadeImpl.java
@@ -1,0 +1,119 @@
+package com.jimjim.lugeasy.notification.application.v1;
+
+import com.jimjim.lugeasy.match.domain.MatchingStatus;
+import com.jimjim.lugeasy.notification.application.v1.dto.NotificationResponseDTO;
+import com.jimjim.lugeasy.notification.domain.Notification;
+import com.jimjim.lugeasy.notification.service.NotificationService;
+import com.jimjim.lugeasy.notification.service.impl.NotificationServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationFacadeImpl implements NotificationFacade {
+    
+    // Notification Domain
+    private final NotificationService notificationService;
+    
+    @Override
+    public NotificationResponseDTO.NotificationListResponse getNotifications(Long memberId) {
+        log.info("알림 조회 시작 - memberId: {}", memberId);
+        
+        // 디버깅용: 모든 알림 조회
+        List<Notification> allNotifications = ((NotificationServiceImpl) notificationService).getAllNotificationsForDebug(memberId);
+        log.info("전체 알림 개수: {}", allNotifications.size());
+        allNotifications.forEach(n -> log.info("알림 ID: {}, Member ID: {}, Matching ID: {}, CreatedAt: {}", 
+                n.getId(), n.getMember().getId(), n.getMatching().getId(), n.getCreatedAt()));
+        
+        // 오늘 알림 조회
+        List<Notification> todayNotifications = notificationService.getTodayNotifications(memberId);
+        log.info("오늘 알림 개수: {}", todayNotifications.size());
+        
+        // 지난 알림 조회
+        List<Notification> earlierNotifications = notificationService.getEarlierNotifications(memberId);
+        log.info("지난 알림 개수: {}", earlierNotifications.size());
+        
+        // DTO 변환
+        List<NotificationResponseDTO.NotificationDetail> todayDetails = todayNotifications.stream()
+                .map(this::convertToNotificationDetail)
+                .collect(Collectors.toList());
+        
+        List<NotificationResponseDTO.NotificationDetail> earlierDetails = earlierNotifications.stream()
+                .map(this::convertToNotificationDetail)
+                .collect(Collectors.toList());
+        
+        return NotificationResponseDTO.NotificationListResponse.builder()
+                .todayNotifications(todayDetails)
+                .earlierNotifications(earlierDetails)
+                .build();
+    }
+    
+    @Override
+    @Transactional
+    public void deleteNotification(Long notificationId, Long memberId) {
+        notificationService.deleteNotification(notificationId, memberId);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteAllNotifications(Long memberId) {
+        notificationService.deleteAllNotifications(memberId);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteTodayNotifications(Long memberId) {
+        notificationService.deleteTodayNotifications(memberId);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteEarlierNotifications(Long memberId) {
+        notificationService.deleteEarlierNotifications(memberId);
+    }
+    
+    /**
+     * 알림 엔티티를 DTO로 변환합니다.
+     * 
+     * @param notification 알림 엔티티
+     * @return 알림 상세 DTO
+     */
+    private NotificationResponseDTO.NotificationDetail convertToNotificationDetail(Notification notification) {
+        // 메시지 동적 생성
+        String message = createNotificationMessage(notification);
+        
+        return NotificationResponseDTO.NotificationDetail.builder()
+                .notificationId(notification.getId())
+                .message(message)
+                .matchingStatus(notification.getMatchingStatus())
+                .otherMemberName(notification.getOtherMemberName())
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+    
+    /**
+     * 알림 메시지를 동적으로 생성합니다.
+     * 
+     * @param notification 알림 정보
+     * @return 생성된 메시지
+     */
+    private String createNotificationMessage(Notification notification) {
+        String otherMemberName = notification.getOtherMemberName();
+        MatchingStatus matchingStatus = notification.getMatchingStatus();
+        
+        return switch (matchingStatus) {
+            case REQUESTED -> otherMemberName + "님에게 매칭 요청이 들어왔어요.";
+            case MATCHED -> otherMemberName + "님과의 매칭이 완료되었어요.";
+            case COMPLETED -> otherMemberName + "님과의 매칭이 완료되었어요.";
+            case REJECTED -> otherMemberName + "님의 매칭 요청이 거절되었어요.";
+        };
+    }
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/application/v1/dto/NotificationResponseDTO.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/application/v1/dto/NotificationResponseDTO.java
@@ -1,0 +1,53 @@
+package com.jimjim.lugeasy.notification.application.v1.dto;
+
+import com.jimjim.lugeasy.match.domain.MatchingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "알림 응답 DTO")
+public class NotificationResponseDTO {
+    
+    @Schema(description = "알림 목록 조회 응답")
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationListResponse {
+        @Schema(description = "오늘 알림 목록")
+        private List<NotificationDetail> todayNotifications;
+        
+        @Schema(description = "지난 알림 목록")
+        private List<NotificationDetail> earlierNotifications;
+    }
+    
+    @Schema(description = "알림 상세 정보")
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationDetail {
+        @Schema(description = "알림 ID", example = "1")
+        private Long notificationId;
+        
+        @Schema(description = "알림 메시지", example = "홍길동님과의 매칭이 완료되었어요.")
+        private String message;
+        
+        @Schema(description = "매칭 상태", example = "MATCHED")
+        private MatchingStatus matchingStatus;
+        
+        @Schema(description = "상대방 이름", example = "홍길동")
+        private String otherMemberName;
+        
+        @Schema(description = "읽음 여부", example = "false")
+        private Boolean isRead;
+        
+        @Schema(description = "생성 시간", example = "2024-01-01T10:00:00")
+        private LocalDateTime createdAt;
+    }
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/domain/Notification.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/domain/Notification.java
@@ -1,0 +1,67 @@
+package com.jimjim.lugeasy.notification.domain;
+
+import com.jimjim.lugeasy.common.entity.BaseEntity;
+import com.jimjim.lugeasy.match.domain.Matching;
+import com.jimjim.lugeasy.match.domain.MatchingStatus;
+import com.jimjim.lugeasy.user.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matching_id", nullable = false)
+    private Matching matching;
+    
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isRead = false;
+    
+    /**
+     * 매칭 상태를 반환합니다.
+     * 
+     * @return 매칭 상태
+     */
+    public MatchingStatus getMatchingStatus() {
+        return this.matching.getMatchingStatus();
+    }
+    
+    /**
+     * 상대방 이름을 반환합니다.
+     * 
+     * @return 상대방 이름
+     */
+    public String getOtherMemberName() {
+        // 알림을 받는 회원이 호스트인 경우, 매칭을 요청한 멤버의 이름을 반환
+        if (this.matching.getHost().getMember().getId().equals(this.member.getId())) {
+            return this.matching.getMember().getName();
+        }
+        // 알림을 받는 회원이 멤버인 경우, 호스트의 이름을 반환
+        else {
+            return this.matching.getHost().getMember().getName();
+        }
+    }
+    
+    /**
+     * 알림을 읽음 처리합니다.
+     */
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/errorCode/NotificationErrorCode.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/errorCode/NotificationErrorCode.java
@@ -1,0 +1,28 @@
+package com.jimjim.lugeasy.notification.errorCode;
+
+import com.jimjim.lugeasy.common.error.ErrorCode;
+import com.jimjim.lugeasy.common.error.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements ErrorCodeInterface {
+    NOTIFICATION_NOT_FOUND("NOTIFICATION001", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_ACCESS_DENIED("NOTIFICATION002", "알림에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INVALID_NOTIFICATION_DATA("NOTIFICATION003", "잘못된 알림 데이터입니다.", HttpStatus.BAD_REQUEST);
+    
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+    
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.builder()
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/infrastructure/NotificationRepository.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/infrastructure/NotificationRepository.java
@@ -1,0 +1,107 @@
+package com.jimjim.lugeasy.notification.infrastructure;
+
+import com.jimjim.lugeasy.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    
+    /**
+     * 회원의 알림 목록을 조회합니다.
+     * 
+     * @param memberId 회원 ID
+     * @return 알림 목록
+     */
+    List<Notification> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+    
+    /**
+     * 회원의 모든 알림을 조회합니다 (디버깅용).
+     * 
+     * @param memberId 회원 ID
+     * @return 알림 목록
+     */
+    List<Notification> findByMemberId(Long memberId);
+    
+    /**
+     * 회원의 오늘 알림 목록을 조회합니다.
+     * 
+     * @param memberId 회원 ID
+     * @param startOfDay 오늘 시작 시간
+     * @param endOfDay 오늘 끝 시간
+     * @return 오늘 알림 목록
+     */
+    @Query("SELECT n FROM Notification n WHERE n.member.id = :memberId " +
+           "AND n.createdAt >= :startOfDay AND n.createdAt < :endOfDay " +
+           "ORDER BY n.createdAt DESC")
+    List<Notification> findTodayNotificationsByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+    
+    /**
+     * 회원의 지난 알림 목록을 조회합니다.
+     * 
+     * @param memberId 회원 ID
+     * @param startOfDay 오늘 시작 시간
+     * @return 지난 알림 목록
+     */
+    @Query("SELECT n FROM Notification n WHERE n.member.id = :memberId " +
+           "AND n.createdAt < :startOfDay " +
+           "ORDER BY n.createdAt DESC")
+    List<Notification> findEarlierNotificationsByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("startOfDay") LocalDateTime startOfDay
+    );
+    
+    /**
+     * 회원의 특정 알림을 조회합니다.
+     * 
+     * @param notificationId 알림 ID
+     * @param memberId 회원 ID
+     * @return 알림
+     */
+    @Query("SELECT n FROM Notification n WHERE n.id = :notificationId AND n.member.id = :memberId")
+    Notification findByIdAndMemberId(@Param("notificationId") Long notificationId, @Param("memberId") Long memberId);
+    
+    /**
+     * 회원의 모든 알림을 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteByMemberId(Long memberId);
+    
+    /**
+     * 회원의 오늘 알림을 모두 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     * @param startOfDay 오늘 시작 시간
+     * @param endOfDay 오늘 끝 시간
+     */
+    @Query("DELETE FROM Notification n WHERE n.member.id = :memberId " +
+           "AND n.createdAt >= :startOfDay AND n.createdAt < :endOfDay")
+    void deleteTodayNotificationsByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+    
+    /**
+     * 회원의 지난 알림을 모두 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     * @param startOfDay 오늘 시작 시간
+     */
+    @Query("DELETE FROM Notification n WHERE n.member.id = :memberId " +
+           "AND n.createdAt < :startOfDay")
+    void deleteEarlierNotificationsByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("startOfDay") LocalDateTime startOfDay
+    );
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/representation/v1/NotificationController.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/representation/v1/NotificationController.java
@@ -1,0 +1,121 @@
+package com.jimjim.lugeasy.notification.representation.v1;
+
+import com.jimjim.lugeasy.common.response.BaseResponse;
+import com.jimjim.lugeasy.common.security.AuthenticationMember;
+import com.jimjim.lugeasy.notification.application.v1.NotificationFacade;
+import com.jimjim.lugeasy.notification.application.v1.dto.NotificationResponseDTO;
+import com.jimjim.lugeasy.user.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+@Tag(name = "Notification", description = "알림 관련 API")
+public class NotificationController {
+    
+    private final NotificationFacade notificationFacade;
+    
+    @GetMapping
+    @Operation(summary = "알림 목록 조회", description = "회원의 알림 목록을 오늘/지난 알림으로 분리하여 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                examples = @ExampleObject(
+                    name = "알림 목록 조회 성공 응답",
+                    value = """
+                    {
+                      "timestamp": "2024-01-01T10:00:00.000Z",
+                      "code": "COMMON200",
+                      "message": "요청에 성공하였습니다.",
+                      "result": {
+                        "todayNotifications": [
+                          {
+                            "notificationId": 1,
+                            "message": "홍길동님과의 매칭이 완료되었어요.",
+                            "matchingStatus": "MATCHED",
+                            "otherMemberName": "홍길동",
+                            "isRead": false,
+                            "createdAt": "2024-01-01T10:00:00"
+                          }
+                        ],
+                        "earlierNotifications": [
+                          {
+                            "notificationId": 2,
+                            "message": "김철수님에게 매칭 요청이 들어왔어요.",
+                            "matchingStatus": "REQUESTED",
+                            "otherMemberName": "김철수",
+                            "isRead": true,
+                            "createdAt": "2024-01-01T09:00:00"
+                          }
+                        ]
+                      }
+                    }
+                    """
+                )
+            )
+        )
+    })
+    public BaseResponse<NotificationResponseDTO.NotificationListResponse> getNotifications(
+            @Parameter(hidden = true) @AuthenticationMember Member member) {
+        
+        return BaseResponse.onSuccess(notificationFacade.getNotifications(member.getId()));
+    }
+    
+    @DeleteMapping("/{notificationId}")
+    @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "알림 삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없음")
+    })
+    public BaseResponse<Void> deleteNotification(
+            @Parameter(description = "알림 ID", example = "1") @PathVariable Long notificationId,
+            @Parameter(hidden = true) @AuthenticationMember Member member) {
+        
+        notificationFacade.deleteNotification(notificationId, member.getId());
+        return BaseResponse.onSuccess(null);
+    }
+    
+    @DeleteMapping
+    @Operation(summary = "모든 알림 삭제", description = "회원의 모든 알림을 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "모든 알림 삭제 성공")
+    })
+    public BaseResponse<Void> deleteAllNotifications(
+            @Parameter(hidden = true) @AuthenticationMember Member member) {
+        
+        notificationFacade.deleteAllNotifications(member.getId());
+        return BaseResponse.onSuccess(null);
+    }
+    
+    @DeleteMapping("/today")
+    @Operation(summary = "오늘 알림 삭제", description = "회원의 오늘 알림을 모두 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "오늘 알림 삭제 성공")
+    })
+    public BaseResponse<Void> deleteTodayNotifications(
+            @Parameter(hidden = true) @AuthenticationMember Member member) {
+        
+        notificationFacade.deleteTodayNotifications(member.getId());
+        return BaseResponse.onSuccess(null);
+    }
+    
+    @DeleteMapping("/earlier")
+    @Operation(summary = "지난 알림 삭제", description = "회원의 지난 알림을 모두 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "지난 알림 삭제 성공")
+    })
+    public BaseResponse<Void> deleteEarlierNotifications(
+            @Parameter(hidden = true) @AuthenticationMember Member member) {
+        
+        notificationFacade.deleteEarlierNotifications(member.getId());
+        return BaseResponse.onSuccess(null);
+    }
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/service/NotificationService.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/service/NotificationService.java
@@ -1,0 +1,73 @@
+package com.jimjim.lugeasy.notification.service;
+
+import com.jimjim.lugeasy.match.domain.Matching;
+import com.jimjim.lugeasy.notification.domain.Notification;
+import com.jimjim.lugeasy.user.domain.Member;
+
+import java.util.List;
+
+public interface NotificationService {
+    
+    /**
+     * 매칭 상태 변경에 따른 알림을 생성합니다.
+     * 
+     * @param matching 매칭 정보
+     * @param targetMember 알림을 받을 회원
+     * @return 생성된 알림
+     */
+    Notification createNotification(Matching matching, Member targetMember);
+    
+    /**
+     * 알림을 조회합니다.
+     * 
+     * @param notificationId 알림 ID
+     * @param memberId 회원 ID
+     * @return 알림 정보
+     */
+    Notification getNotification(Long notificationId, Long memberId);
+    
+    /**
+     * 알림을 삭제합니다.
+     * 
+     * @param notificationId 알림 ID
+     * @param memberId 회원 ID
+     */
+    void deleteNotification(Long notificationId, Long memberId);
+    
+    /**
+     * 회원의 모든 알림을 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteAllNotifications(Long memberId);
+    
+    /**
+     * 회원의 오늘 알림을 모두 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteTodayNotifications(Long memberId);
+    
+    /**
+     * 회원의 지난 알림을 모두 삭제합니다.
+     * 
+     * @param memberId 회원 ID
+     */
+    void deleteEarlierNotifications(Long memberId);
+    
+    /**
+     * 회원의 오늘 알림 목록을 조회합니다.
+     * 
+     * @param memberId 회원 ID
+     * @return 오늘 알림 목록
+     */
+    List<Notification> getTodayNotifications(Long memberId);
+    
+    /**
+     * 회원의 지난 알림 목록을 조회합니다.
+     * 
+     * @param memberId 회원 ID
+     * @return 지난 알림 목록
+     */
+    List<Notification> getEarlierNotifications(Long memberId);
+}

--- a/lugeasy/src/main/java/com/jimjim/lugeasy/notification/service/impl/NotificationServiceImpl.java
+++ b/lugeasy/src/main/java/com/jimjim/lugeasy/notification/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,98 @@
+package com.jimjim.lugeasy.notification.service.impl;
+
+import com.jimjim.lugeasy.common.error.RestApiException;
+import com.jimjim.lugeasy.match.domain.Matching;
+import com.jimjim.lugeasy.notification.domain.Notification;
+import com.jimjim.lugeasy.notification.errorCode.NotificationErrorCode;
+import com.jimjim.lugeasy.notification.infrastructure.NotificationRepository;
+import com.jimjim.lugeasy.notification.service.NotificationService;
+import com.jimjim.lugeasy.user.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+    
+    private final NotificationRepository notificationRepository;
+    
+    @Override
+    @Transactional
+    public Notification createNotification(Matching matching, Member targetMember) {
+        // 알림 생성 (메시지는 동적으로 생성)
+        Notification notification = Notification.builder()
+                .member(targetMember)
+                .matching(matching)
+                .isRead(false)
+                .build();
+        
+        return notificationRepository.save(notification);
+    }
+    
+    @Override
+    public Notification getNotification(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findByIdAndMemberId(notificationId, memberId);
+        if (notification == null) {
+            throw new RestApiException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+        return notification;
+    }
+    
+    @Override
+    @Transactional
+    public void deleteNotification(Long notificationId, Long memberId) {
+        Notification notification = getNotification(notificationId, memberId);
+        notificationRepository.delete(notification);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteAllNotifications(Long memberId) {
+        notificationRepository.deleteByMemberId(memberId);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteTodayNotifications(Long memberId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+        
+        notificationRepository.deleteTodayNotificationsByMemberId(memberId, startOfDay, endOfDay);
+    }
+    
+    @Override
+    @Transactional
+    public void deleteEarlierNotifications(Long memberId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        notificationRepository.deleteEarlierNotificationsByMemberId(memberId, startOfDay);
+    }
+    
+    @Override
+    public List<Notification> getTodayNotifications(Long memberId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+        
+        return notificationRepository.findTodayNotificationsByMemberId(memberId, startOfDay, endOfDay);
+    }
+    
+    @Override
+    public List<Notification> getEarlierNotifications(Long memberId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        return notificationRepository.findEarlierNotificationsByMemberId(memberId, startOfDay);
+    }
+    
+    /**
+     * 디버깅용: 회원의 모든 알림을 조회합니다.
+     */
+    public List<Notification> getAllNotificationsForDebug(Long memberId) {
+        return notificationRepository.findByMemberId(memberId);
+    }
+    
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#19/notificationAPI -> develop

### 변경 사항
- 알림 CRUD 구현
- 매칭 상태 변경 API 구현
- 매칭 상태 변경 조건 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added notifications: view today/earlier lists and delete single, all, today, or earlier notifications (authentication required).
  - Match management: update match status via PATCH; notifications sent to the other participant on changes.
  - Match listings: new “as-member” endpoint and unified list including host/member roles.
  - Response enhancements: match responses now include member_id, member_name, and user_role.
- Documentation
  - Added guidelines for controller responsibilities and authenticated member injection, plus usage/style notes for request/response mapping and Swagger annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->