### PR TITLE
Alb target to 8080

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -50,7 +50,7 @@ resource "aws_lb" "lugeasy_alb" {
 
 resource "aws_lb_target_group" "lugeasy_tg" {
   name        = "lugeasy-tg"
-  port        = 8000               
+  port        = 8080               
   protocol    = "HTTP"
   target_type = "instance"
   vpc_id      = data.aws_vpc.lugeasy_vpc.id
@@ -73,7 +73,7 @@ resource "aws_lb_target_group" "lugeasy_tg" {
 resource "aws_lb_target_group_attachment" "lugeasy_tg_attach_ec2" {
   target_group_arn = aws_lb_target_group.lugeasy_tg.arn
   target_id        = aws_instance.lugeasy_ec2.id
-  port             = 8000          
+  port             = 8080
 }
 
 resource "aws_lb_listener" "http_80_redirect_to_https" {

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -50,7 +50,7 @@ resource "aws_lb" "lugeasy_alb" {
 
 resource "aws_lb_target_group" "lugeasy_tg" {
   name        = "lugeasy-tg"
-  port        = 80
+  port        = 8000               
   protocol    = "HTTP"
   target_type = "instance"
   vpc_id      = data.aws_vpc.lugeasy_vpc.id
@@ -58,7 +58,7 @@ resource "aws_lb_target_group" "lugeasy_tg" {
   health_check {
     enabled             = true
     protocol            = "HTTP"
-    path                = "/"
+    path                = "/"     
     matcher             = "200-399"
     interval            = 30
     timeout             = 5
@@ -69,12 +69,12 @@ resource "aws_lb_target_group" "lugeasy_tg" {
   tags = { Name = "lugeasy-tg" }
 }
 
+
 resource "aws_lb_target_group_attachment" "lugeasy_tg_attach_ec2" {
   target_group_arn = aws_lb_target_group.lugeasy_tg.arn
   target_id        = aws_instance.lugeasy_ec2.id
-  port             = 80
+  port             = 8000          
 }
-
 
 resource "aws_lb_listener" "http_80_redirect_to_https" {
   load_balancer_arn = aws_lb.lugeasy_alb.arn

--- a/infra/data.tf
+++ b/infra/data.tf
@@ -40,3 +40,8 @@ data "aws_subnet" "lugeasy_private_subnet" {
     values = [data.aws_vpc.lugeasy_vpc.id]
   }
 }
+
+data "aws_key_pair" "lugeasy" {
+  key_name = "lugeasy-server-key-pair"
+}
+

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -60,21 +60,30 @@ resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_22_ingress_rule" {
   to_port           = 22
 }
 
-resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_80_ingress_rule" {
-  security_group_id = aws_security_group.lugeasy_ec2_security_group.id
-  cidr_ipv4         =  "0.0.0.0/0"
-  from_port         = 80
-  ip_protocol       = "tcp"
-  to_port           = 80
+resource "aws_vpc_security_group_ingress_rule" "ec2_allow_8000_from_alb" {
+  security_group_id            = aws_security_group.lugeasy_ec2_security_group.id
+  ip_protocol                  = "tcp"
+  from_port                    = 8000
+  to_port                      = 8000
+  referenced_security_group_id = aws_security_group.lugeasy_alb_sg.id
+  description                  = "Allow HTTP 8000 only from ALB SG"
 }
 
-resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_443_ingress_rule" {
-  security_group_id = aws_security_group.lugeasy_ec2_security_group.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 443
-  ip_protocol       = "tcp"
-  to_port           = 443
-}
+# resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_80_ingress_rule" {
+#   security_group_id = aws_security_group.lugeasy_ec2_security_group.id
+#   cidr_ipv4         =  "0.0.0.0/0"
+#   from_port         = 80
+#   ip_protocol       = "tcp"
+#   to_port           = 80
+# }
+
+# resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_443_ingress_rule" {
+#   security_group_id = aws_security_group.lugeasy_ec2_security_group.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   from_port         = 443
+#   ip_protocol       = "tcp"
+#   to_port           = 443
+# }
 
 # egress rule
 resource "aws_security_group_rule" "lugeasy_ec2_any_open_egress_rule" {

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -23,6 +23,8 @@ resource "aws_instance" "lugeasy_ec2" {
   user_data                  = file("${path.module}/nginx.sh")
   user_data_replace_on_change = true
 
+  key_name = data.aws_key_pair.lugeasy.key_name
+
   tags = {
     Name = "lugeasy-ec2"
   }
@@ -60,13 +62,13 @@ resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_22_ingress_rule" {
   to_port           = 22
 }
 
-resource "aws_vpc_security_group_ingress_rule" "ec2_allow_8000_from_alb" {
+resource "aws_vpc_security_group_ingress_rule" "ec2_allow_8080_from_alb" {
   security_group_id            = aws_security_group.lugeasy_ec2_security_group.id
   ip_protocol                  = "tcp"
-  from_port                    = 8000
-  to_port                      = 8000
+  from_port                    = 8080
+  to_port                      = 8080
   referenced_security_group_id = aws_security_group.lugeasy_alb_sg.id
-  description                  = "Allow HTTP 8000 only from ALB SG"
+  description                  = "Allow HTTP 8080 only from ALB SG"
 }
 
 # resource "aws_vpc_security_group_ingress_rule" "lugeasy_ec2_80_ingress_rule" {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/login -> develop

### 변경 사항
- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated application infrastructure from port 80 to port 8080 across both the load balancer and compute instance configurations.
  * Refined security group ingress rules to restrict compute instance inbound traffic exclusively to port 8080 from the load balancer, removing previous port 80 and 443 rules.
  * Added SSH key pair configuration to the compute instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->